### PR TITLE
Enable Support for QT6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,8 @@ endif()
 set(SRC_DIR "${PROJECT_SOURCE_DIR}/src")
 
 include(GNUInstallDirs)
-find_package(Qt5 COMPONENTS Core Quick Qml Gui CONFIG REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core CONFIG REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Quick Qml Gui CONFIG REQUIRED)
 
 set(quickflux_PRIVATE_SOURCES
   ${SRC_DIR}/priv/qfhook.cpp
@@ -99,9 +100,9 @@ add_library(QuickFlux::quickflux ALIAS quickflux)
 
 target_link_libraries(quickflux
   PUBLIC
-  Qt5::Qml
-  Qt5::Quick
-  Qt5::Core
+  Qt${QT_VERSION_MAJOR}::Qml
+  Qt${QT_VERSION_MAJOR}::Quick
+  Qt${QT_VERSION_MAJOR}::Core
   )
 
 target_include_directories(quickflux

--- a/src/priv/qfsignalproxy.cpp
+++ b/src/priv/qfsignalproxy.cpp
@@ -49,7 +49,11 @@ int QFSignalProxy::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
                 if (type == QMetaType::QVariant) {
                     v = *reinterpret_cast<QVariant *>(_a[i + 1]);
                 } else {
+                    #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                    v = QVariant(QMetaType{type}, _a[i + 1]);
+                    #else
                     v = QVariant(type, _a[i + 1]);
+                    #endif
                 }
 
                 message[parameterNames.at(i)] = v;

--- a/src/qfstore.cpp
+++ b/src/qfstore.cpp
@@ -125,7 +125,11 @@ QFStore::QFStore(QObject *parent) : QObject(parent) , m_filterFunctionEnabled(fa
 
 QQmlListProperty<QObject> QFStore::children()
 {
+    #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), &m_children);
+    #else
     return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), m_children);
+    #endif
 }
 
 void QFStore::dispatch(QString type, QJSValue message)
@@ -245,7 +249,11 @@ void QFStore::setup()
 
 QQmlListProperty<QObject> QFStore::redispatchTargets()
 {
+    #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), &m_redispatchTargets);
+    #else
     return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), m_redispatchTargets);
+    #endif
 }
 
 


### PR DESCRIPTION
In the CMakeLists.txt add a branch to check of qt6 is available. If it is, use that, otherwise assume QT5.

In qfsignalproxy slightly adapt call to constructor of QVariant. QVariant(type, void*) signature has changed between QT5 and QT6.

in qfstore adapt call to constructor of QQmlListProperty. Signature has changed between QT5.13 and QT6